### PR TITLE
Fix deprecated import in flatten_utils.py

### DIFF
--- a/irs_reader/flatten_utils.py
+++ b/irs_reader/flatten_utils.py
@@ -7,7 +7,7 @@ def flatten(d, parent_key='', sep='/'):
     if d:
         for k, v in d.items():
             new_key = parent_key + sep + k if parent_key else k
-            if isinstance(v, collections.MutableMapping):
+            if isinstance(v, collections.abc.MutableMapping):
                 items.extend(flatten(v, new_key, sep=sep).items())
             else:
                 new_key = new_key.replace("/#text","")


### PR DESCRIPTION
Prevents breakage from upcoming change in Python 3.10, which will make `MutableMapping` only accessible through `collections.abc`.

Issue was picked up while running pytest on a project using irsx, which raised this warning:

> DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working

Currently `collections.MutableMapping` and `collections.abc.MutableMapping` point to the same class:
```
from collections import MutableMapping as MM
from collections.abc import MutableMapping as abcMM
assert MM is abcMM
```